### PR TITLE
JRNY-165 | Only render primary navbar when logged in

### DIFF
--- a/apps/journey-accounts/src/app/app.routes.tsx
+++ b/apps/journey-accounts/src/app/app.routes.tsx
@@ -13,6 +13,7 @@ import { ProfileRoutes } from './pages/Profile/Profile.routes';
 import { SecurityRoutes } from './pages/Security/Security.routes';
 import { AuthGuard } from './components/Auth/AuthGuard';
 import { AsideNavbar } from './components/Nav/Aside/AsideNavbar';
+import { PrimaryNavbar } from './components/Nav/Primary/PrimaryNavbar';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 interface AppRoutesProps {}
@@ -36,6 +37,7 @@ export const AppRoutes: FC<AppRoutesProps> = (props: AppRoutesProps) => {
             <Route
               element={
                 <Layout
+                  primaryNavbar={<PrimaryNavbar />}
                   aside={<AsideNavbar />}
                   body={
                     <Animate>

--- a/apps/journey-accounts/src/app/app.tsx
+++ b/apps/journey-accounts/src/app/app.tsx
@@ -53,14 +53,11 @@ export function App() {
         <NotificationProvider>
           <UserProvider>
             <ErrorProvider>
-              <LayoutHeader>
-                <div className={styles['skip-link']}>
-                  <SkipLink clickHandler={skipToMainContent}>
-                    Skip to main content
-                  </SkipLink>
-                </div>
-                <PrimaryNavbar />
-              </LayoutHeader>
+              <div className={styles['skip-link']}>
+                <SkipLink clickHandler={skipToMainContent}>
+                  Skip to main content
+                </SkipLink>
+              </div>
               <AppRoutes />
               <div className={styles['notification-container']}>
                 <Notification />

--- a/apps/journey-accounts/src/app/components/Nav/Primary/PrimaryNavbar.spec.tsx
+++ b/apps/journey-accounts/src/app/components/Nav/Primary/PrimaryNavbar.spec.tsx
@@ -66,7 +66,6 @@ describe('PrimaryNavbar', () => {
 
   it('should render', () => {
     expect(component).toBeTruthy();
-    expect(query('brand-button')).toBeTruthy();
   });
 
   it('should hide buttons if user is not logged in', () => {

--- a/apps/journey-accounts/src/app/components/Nav/Primary/PrimaryNavbar.tsx
+++ b/apps/journey-accounts/src/app/components/Nav/Primary/PrimaryNavbar.tsx
@@ -32,11 +32,7 @@ export const PrimaryNavbar: FC<PrimaryNavbarProps> = (
     <nav className="navbar" role="navigation" aria-label="primary navigation">
       <div className="navbar-brand column is-one-third">
         <div className="navbar-item">
-          <h2 data-testid="brand-button" className="subtitle">
-            <Link className={styles['navbar-brand-link']} to="/">
-              Journey
-            </Link>
-          </h2>
+          <h2 className="subtitle">Journey</h2>
         </div>
       </div>
 


### PR DESCRIPTION
# Changes
- Primary navbar in Accounts is only visible when logged in
- Changed navbar brand to regular text

# Screenshots
Before:
<img width="1440" alt="Screen Shot 2022-09-22 at 8 25 28 PM" src="https://user-images.githubusercontent.com/113420241/191872946-9c927f3c-7d97-49e4-a0a5-efd55ab68e65.png">

After:
<img width="1440" alt="Screen Shot 2022-09-22 at 8 25 12 PM" src="https://user-images.githubusercontent.com/113420241/191872956-c5361dbf-1b2b-4f6c-a859-98ebb88aeecb.png">

# Checklist
- [x] Does not include unrelated changes.
- [x] Feature changes include new tests or adjustments to existing tests.
- [x] Changes have been checked for accessibility:
  - [x] All interactive elements can be reached by keyboard.
  - [ ] ARIA is used where semantic HTML is not possible.
  - [ ] Form controls have corresponding labels and ARIA attributes.
  - [x] Expected behavior has been verified with a screen reader.

# Testing steps
- Checkout branch & start db/app for Accounts
- Verify navbar is only visible when logged in